### PR TITLE
Accept files dropped on the CommandsWindow

### DIFF
--- a/Source/CommandsWindow.cpp
+++ b/Source/CommandsWindow.cpp
@@ -115,6 +115,7 @@ void
 CommandsWindow::MessageReceived(BMessage* message)
 {
 	switch (message->what) {
+		case B_SIMPLE_DATA:
 		case B_REFS_RECEIVED:
 			_RefsReceived(message);
 			break;


### PR DESCRIPTION
Puts a dropped script file's path into the "Command" text control.